### PR TITLE
WIP: Integrate `Monitor` into a `@monitored` context

### DIFF
--- a/src/functions/monitored.ts
+++ b/src/functions/monitored.ts
@@ -1,0 +1,28 @@
+
+// IF you have a `@monitored`
+// That means you have `@timedCancellable` at thes ame time
+// You can do `@timed` `@cancellable`
+// But instead `@timedCancellable` combines them all
+// SO @monitored does it too
+// Cause if you can lock things... you can also use the timer and monitor
+// Due to the usageo f the locking ctx
+// await ctx.monitor.lock(...)
+// someotherfunction(ctx)
+// it passes the monitor down there
+// Well the problem is that whe nyou do it
+// you'd need to have the timer monitor applied?
+// you don'tn eed to apply the ctx
+// the ctx is automtaically applied( so the function ctx of timer and signal)
+// isautomatically applied to all LOCKS
+// when you do this you also need to use the ability to create a monitor
+// obj.withMonitor(async (monitor) => {
+// })
+
+// I wnat to see to quickly prototyep what this will look like
+
+
+function monitored() {
+
+}
+
+export default monitored;


### PR DESCRIPTION
### Description

This will make it easier to use the `Monitor` in various class methods such as in `js-quic.

This creates a HOF called `monitored` as well as class method decorator called `@monitored`.

We can imagine a class like this:

```ts
class X {
  public f(ctx?: Partial<ContextMonitoredInput>): Promise<void>;
  @monitored()
  public async f(@context ctx: ContextMonitored): Promise<void> {
    await ctx.monitor.lock('a'); // Mutual exclusion indexed by `a`
  }

  public g(ctx?: Partial<ContextMonitoredInput>): Promise<void>;
  @monitored()
  public async g(@context ctx: ContextMonitored): Promise<void> {
    await ctx.monitor.lock('a'); // Mutual exclusion indexed by `a`
  }
}
```

And equivalent for the `monitored` HOF.

There are several decision decisions we have to make here.

1. Where does the `LockBox<RWLock>` stay? Consider that the `@monitored` would require the ability to point to a shared lock box object. We can imagine a few places where it can exist. The first place would as a symbol property of the instantiated class. This is doable just through an additional class decorator, but it is also possible to lazily instantiate this just through the `@monitored()` decorator call. Furthermore it should also be possible to inject a lock box at that call in case the `@monitored` decorator can use separate share lockboxes.
2. At the same time when creating the lockbox, one must also choose the appropriate `lockConstructor: new () => RWLock`. I think this can be defaulted to `RWLockWriter`, in which case the `lockBox` defaults to `LockBox<RWLockWriter>`.
3. Finally for deadlock detection, it's optional, so again this can be something that is part of the class object properties through a symbol (unique symbols prevent name clashes with the underlying class properties), but again it could be something that can be specified. I think the default behaviour would be not to specify it, because the default `Monitor` also doesn't specify it, and it does slow down the monitor usage, and it's best used during prototyping and testing, and once it's confirmed that no deadlocks are possible, it can be dropped from the production code.
4. The `@monitored` could imply `@cancellable` due to the existence of `PromiseCancellable<void>`. Furthermore, we support timers in our `Monitor.lock` method which means actually using `@monitored` could imply `@timedCancellable` too.
5. Now if `@timed` is automatic for `@monitored`, what does this actually mean? Especially for calls to `ctx.monitor.lock()`? Normally `@timed` provides both a `ctx.signal` and `ctx.timer`, however it does not do an automatic rejection like `@cancellable` does. When we are doing `@monitored`, we may not actually want to be able to do automatic rejection, it feels like a separate thing.
6. Therefore it is a separate thing, then one could expect `@monitored` to be combined with `@timedCancellable`, and the order of wrapping does matter here too. Is it `@monitored` first and then `@timedCancellable` second or the other way around? Furthermore is there efficiency gained from combining it into a single decorator like `@monitoredTimedCancellable` or `@timedCancellableMonitored`?
7. If `@timed` or `@cancellable` is combined with `@monitored`, then it must be that the `ctx` must automatically be passed into any `ctx.monitor.lock()` or `ctx.monitor.withF` or `ctx.monitor.waitForUnlock`... etc calls. This is because there's an expectation that ctx is passed down the call graph, but one could easily forget to do this when using the `ctx.monitor.lock` call. And it just seems that if I wanted to either time out the entire operation, then it should time out any locking operations, and if I want to cancel the whole call, then it also makes sense that I would want to cancel any locking operations.
8. What is the API of `ctx.monitor`, is the full `Monitor` API? If so, then one has to actually do `await ctx.monitor.lock('a')()` or use it as part of the `withF(ctx.monitor.lock('a'), async () => { ... }`. This isn't that bad, but it does require a little more effort then the `DBTransaction.lock` call. The main reason is to align the API similar to other resources.
9. When `@monitored` is used, there needs to be a way to "construct" a monitor from scratch. For example in `@timed`, one can create a `new Timer`, and for `@cancellable`, one can create a `new AbortController`, but one cannot create a `new Monitor` without being able to refer to the shared lock box some how. I think if the lock box was exposed through a symbol property like `obj[lockBox]`, then it would be possible to construct a new monitor like `obj.method({ monitor: new Monitor(obj[lockBox], obj[lockConstructor], obj[locksPending]) }`. The only issue here is that there's automatic destruction of the monitor, if you do this, you need to close the monitor somehow at the end with `await monitor.unlockAll()`. This is usually why we have a convenience function called `withF()` or `withMonitorF` or `withTransactionF` such as in the `DB`. This isn't necessary for the `Timer` or `AbortController`, because they can be garbage collected, but now I realise it does actually make sense to do so... to get around this it may make sense for the user to provide a method to create these resources and then combine it with `withF`. Even the `Timer` requires automatic cancellation...

```ts
class X {
  public f(ctx?: Partial<ContextMonitoredInput>): Promise<void>;
  @monitored()
  public async f(@context ctx: ContextMonitored): Promise<void> {
    console.log(ctx.monitor);
    await ctx.monitor.lock('a');
  }
}

const x = new X();
```

Right now this what you'd do similar to `new Timer` or `new AbortController`.

```ts
// Assume you needed to create a fresh monitor from scratch
const monitor = new Monitor(x[lockBox], x[lockConstructor]);
await x.f({ monitor });
// You need to remember to clear it yourself
await monitor.unlockAll();
```

Alternatively:

```ts
// Convenience bracket-pattern function for creating a monitor resource
function monitor(): ResourceAcquire<Monitor<RWLock>> {
  return async () => {
    const monitor = new Monitor(x[lockBox], x[lockConstructor]);
    return [
      async () => {
        await monitor.unlockAll();
      },
      monitor
    ];
  };
}

// Now we can use this instead
await withF(monitor(), async ([mon]) => {
  await x.f({ monitor: mon });
});
```

Alternatively:

```ts
// What if we had the convenience function embedded in the object?
await x.withMonitorF(async ([mon]) => {
  await x.f({ monitor: mon });
});

// And you could also call it directly
const mon =  x.monitor();
```

To prevent nameclashes, you'd have to use a symbol method:

```ts
import { monitor, withMonitorF, withMonitorG }

await x[withMonitorF](async ([mon]) => {
  // ...
});

await x[withMonitorG](async ([mon]) => {
  // ...
});

const mon =  x[monitor]();
```

Note that this pattern is called a "mix-in" pattern. We are mixing-in the ability to create specific resources and bracketing methods for the object. This is primarily useful when we expect the "unit of atomicity" to be any method with the `@monitored` decorator applied. However if the unit of atomicity is expanded beyond one single class, then you wouldn't want to use those mixins, since they imply a single-class unit. This is why `@monitored` should not automatically mixin those methods. There should also be a class decorator that supports the mixins if you want.

It might look like:

```ts
// Class decorators are always capitalised
@Monitored()
class X {
  public f(ctx?: Partial<ContextMonitoredInput>): Promise<void>;
  @monitored()
  public async f(@context ctx: ContextMonitored): Promise<void> {
    console.log(ctx.monitor);
    await ctx.monitor.lock('a');
  }
}
```

All of it does add a bit of verbosity though.

So if we were to combine `@timedCancellable`, it seems that it would make sense to decorate `@timedCancellable` first. I think the order of decorators mathematical.

```ts
@Monitored()
class X {
  public f(ctx?: Partial<ContextMonitoredInput>): Promise<void>;
  @timedCancellable()
  @monitored()
  public async f(@context ctx: ContextMonitored): Promise<void> {
    console.log(ctx.monitor);
    await ctx.monitor.lock('a');
  }
}
```

This should create a situation where the `@timedCancellable` is the last wrapper, and returns a function that will take `ContextTimedInput`. This will produce `ContextTimed` internally. Then when `monitored` function takes the `ContextTimed`, it can make use of the `ctx.timer` and `ctx.signal` and autopropagate them into the `ctx.monitor.lock()` calls.

That would require:

```ts
type ContextMonitoredInput = {
  monitor: Monitor<RWLock>;
  signal?: AbortSignal;
  timer?: Timer | number;
}
```

So with the `signal` and `timer` optional, the idea is that these will be auto sent in.

Alternatively we can not bother with automatic injection, less magic, and just expect the user to pass the ctx into `ctx.monitor.lock` call. Something like:

```ts
@Monitored()
class X {
  public f(ctx?: Partial<ContextMonitoredInput>): Promise<void>;
  @timedCancellable()
  @monitored()
  public async f(@context ctx: ContextMonitored): Promise<void> {
    console.log(ctx.monitor);
    await ctx.monitor.lock('a', ctx);
  }
}
```

Of course we should also upgrade our existing `setup*` functions to support the literal timer as a number as we have done so in `js-async-locks`.

There's quite a few things here to explore...

### Issues Fixed

* Relates https://github.com/MatrixAI/js-async-locks/issues/21
* Relates https://github.com/MatrixAI/js-db/issues/51

### Tasks

- [ ] 1. Install this into `js-contexts`
- [ ] 2. Test out `@monitored` decorator and `monitored` HOF in `js-contexts`
- [ ] 3. Bring in the literal `timer` option as we have in `js-async-locks`, it should make `timer` usage a bit easier too

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixd
* [ ] Squash and rebased
* [ ] Sanity check the final build
